### PR TITLE
Add LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,3 @@
+"THE COFFEEWARE LICENSE" (Revision 2):
+
+gothyra authors wrote this code. As long as you retain this notice you can do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy us a coffee in return.


### PR DESCRIPTION
License source: https://github.com/Jmlevick/coffeeware-license
Didn't include the social media stanza and made the license general
for all authors of this repo.